### PR TITLE
make definition of object property failsafe against omitting `name` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const HTMLParsedElement = (() => {
                 (init.get(this) === true) :
                 isParsed(this);
               if (value)
-                Object.defineProperty(this, name, {value});
+                Object.defineProperty(this, name || 'parsed', {value});
               return value;
             }
           }

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ const HTMLParsedElement = (() => {
               }
             }
           },
-          [name]: {
+          [name || 'parsed']: {
             configurable: true,
             get() {
               const value = init.has(this) ?


### PR DESCRIPTION
Just like you did with the callback name.

So

```js
[name]: {
  configurable: true,
  get() {
    const value = init.has(this) ?
      (init.get(this) === true) :
      isParsed(this);
    if (value)
      Object.defineProperty(this, name, {value});
    return value;
  }
}
```

should probably be

```js
[name || 'parsed']: {
  configurable: true,
  get() {
    const value = init.has(this) ?
      (init.get(this) === true) :
      isParsed(this);
    if (value)
      Object.defineProperty(this, name, {value});
    return value;
  }
}
```